### PR TITLE
Handle copyright/attribution/license attributes

### DIFF
--- a/OSM.cabal
+++ b/OSM.cabal
@@ -59,16 +59,19 @@ Library
                       Data.Geo.OSM.Waynodes
                       Data.Geo.OSM.Lens.AccountCreatedL
                       Data.Geo.OSM.Lens.AreaL
+                      Data.Geo.OSM.Lens.AttributionL
                       Data.Geo.OSM.Lens.BoundsL
                       Data.Geo.OSM.Lens.BoxL
                       Data.Geo.OSM.Lens.ChangesetL
                       Data.Geo.OSM.Lens.ChildrenL
+                      Data.Geo.OSM.Lens.CopyrightL
                       Data.Geo.OSM.Lens.DisplayNameL
                       Data.Geo.OSM.Lens.GeneratorL
                       Data.Geo.OSM.Lens.HomeL
                       Data.Geo.OSM.Lens.IdL
                       Data.Geo.OSM.Lens.KL
                       Data.Geo.OSM.Lens.LatL
+                      Data.Geo.OSM.Lens.LicenseL
                       Data.Geo.OSM.Lens.LonL
                       Data.Geo.OSM.Lens.MaximumL
                       Data.Geo.OSM.Lens.MaxlatL

--- a/src/Data/Geo/OSM/Lens/AttributionL.hs
+++ b/src/Data/Geo/OSM/Lens/AttributionL.hs
@@ -1,0 +1,9 @@
+-- | Values with a @generator@ optional string accessor.
+module Data.Geo.OSM.Lens.AttributionL where
+
+import Control.Lens.Lens
+
+class AttributionL a where
+  attributionL ::
+    Lens' a (Maybe String)
+

--- a/src/Data/Geo/OSM/Lens/CopyrightL.hs
+++ b/src/Data/Geo/OSM/Lens/CopyrightL.hs
@@ -1,0 +1,9 @@
+-- | Values with a @generator@ optional string accessor.
+module Data.Geo.OSM.Lens.CopyrightL where
+
+import Control.Lens.Lens
+
+class CopyrightL a where
+  copyrightL ::
+    Lens' a (Maybe String)
+

--- a/src/Data/Geo/OSM/Lens/LicenseL.hs
+++ b/src/Data/Geo/OSM/Lens/LicenseL.hs
@@ -1,0 +1,9 @@
+-- | Values with a @generator@ optional string accessor.
+module Data.Geo.OSM.Lens.LicenseL where
+
+import Control.Lens.Lens
+
+class LicenseL a where
+  licenseL ::
+    Lens' a (Maybe String)
+

--- a/src/Data/Geo/OSM/OSM.hs
+++ b/src/Data/Geo/OSM/OSM.hs
@@ -30,6 +30,9 @@ import Data.Geo.OSM.BoundOption
 import Control.Lens.TH
 import Data.Geo.OSM.Lens.VersionL
 import Data.Geo.OSM.Lens.GeneratorL
+import Data.Geo.OSM.Lens.CopyrightL
+import Data.Geo.OSM.Lens.AttributionL
+import Data.Geo.OSM.Lens.LicenseL
 import Data.Geo.OSM.Lens.BoundsL
 import Data.Geo.OSM.Lens.ChildrenL
 import Data.Monoid
@@ -38,6 +41,9 @@ import Data.Monoid
 data OSM = OSM {
   _osmVersion :: String,
   _osmGenerator :: (Maybe String),
+  _osmCopyright :: (Maybe String),
+  _osmAttribution :: (Maybe String),
+  _osmLicense :: (Maybe String),
   _osmBounds :: Maybe (Either Bound Bounds),
   _osmChildren :: Children
   } deriving Eq
@@ -46,9 +52,12 @@ makeLenses ''OSM
 
 instance XmlPickler OSM where
   xpickle =
-    xpElem "osm" (xpWrap (\(version', generator', bound', nwr') -> osm version' generator' bound' nwr', \(OSM version' generator' bound' nwr') -> (version', generator', bound', nwr'))
-      (xp4Tuple (xpAttr "version" xpText)
+    xpElem "osm" (xpWrap (\(version', generator', copyright', attribution', license', bound', nwr') -> osm version' generator' copyright' attribution' license' bound' nwr', \(OSM version' generator' copyright' attribution' license' bound' nwr') -> (version', generator', copyright', attribution', license', bound', nwr'))
+      (xp7Tuple (xpAttr "version" xpText)
                 (xpOption (xpAttr "generator" xpText))
+                (xpOption (xpAttr "copyright" xpText))
+                (xpOption (xpAttr "attribution" xpText))
+                (xpOption (xpAttr "license" xpText))
                 (xpOption (xpAlt (either (const 0) (const 1)) [xpWrap (Left, \(Left b) -> b) xpickle, xpWrap (Right, \(Right b) -> b) xpickle]))
                 xpickle))
 
@@ -65,6 +74,15 @@ instance BoundsL OSM where
 instance GeneratorL OSM where
   generatorL = osmGenerator
 
+instance CopyrightL OSM where
+  copyrightL = osmCopyright
+
+instance AttributionL OSM where
+  attributionL = osmAttribution
+
+instance LicenseL OSM where
+  licenseL = osmLicense
+
 instance ChildrenL OSM where
   childrenL = osmChildren
 
@@ -73,6 +91,9 @@ instance ChildrenL OSM where
 osm ::
   String -- ^ The @version@ attribute.
   -> Maybe String -- ^ The @generator@ attribute.
+  -> Maybe String -- ^ The @copyright@ attribute.
+  -> Maybe String -- ^ The @attribution@ attribute.
+  -> Maybe String -- ^ The @license@ attribute.
   -> Maybe (Either Bound Bounds) -- ^ The @bound@ or @bounds@ elements.
   -> Children -- ^ The child elements.
   -> OSM


### PR DESCRIPTION
I can read a `map.osm` of today with this change.